### PR TITLE
fix(APlayer): fix crash right on starting to play on Safari

### DIFF
--- a/src/hooks/useAudioControl.ts
+++ b/src/hooks/useAudioControl.ts
@@ -185,7 +185,16 @@ export function useAudioControl(options: CreateAudioElementOptions) {
       },
       [audioElementRef]
     ),
-    () => audioElementRef.current?.currentTime,
+    () => {
+      if (!audioElementRef.current) {
+        return undefined;
+      }
+
+      // Use `Math.round()` here because
+      //   1. The player UI only displays currentTime at second-level precision
+      //   2. Prevent too many updates (leads to crash on Safari)
+      return Math.round(audioElementRef.current.currentTime);
+    },
     () => undefined
   );
 


### PR DESCRIPTION
Fix #9

The crash is caused by too often updates of `currentTime`, leading to too many re-renders.

<img width="749" alt="image" src="https://user-images.githubusercontent.com/8225666/221836885-14bb0ae5-32ee-492a-ba26-0593d4635962.png">

No clue why it only happens on Safari. Guess it's because `timeupdate` is fired not as often on other browsers as it's on Safari.